### PR TITLE
Fix CORS error when fetching book covers from Amazon

### DIFF
--- a/source/chrome/background.js
+++ b/source/chrome/background.js
@@ -10,12 +10,19 @@ const colorMap = {
 
 async function fetchHighResCover(amazonLink) {
   try {
-    if (!amazonLink || !amazonLink.includes('amazon.com') || !amazonLink.includes('/dp/')) {
+    if (!amazonLink || !amazonLink.includes('amazon') || !amazonLink.includes('/dp/')) {
       console.warn('Invalid Amazon link:', amazonLink);
       return '';
     }
 
-    const response = await fetch(amazonLink, { method: 'GET', credentials: 'omit' });
+    // Normalize URL to use www subdomain to match host_permissions
+    let normalizedUrl = amazonLink;
+    if (amazonLink.includes('://amazon.')) {
+      normalizedUrl = amazonLink.replace('://amazon.', '://www.amazon.');
+    }
+    console.log('Fetching cover from:', normalizedUrl);
+
+    const response = await fetch(normalizedUrl, { method: 'GET', credentials: 'omit' });
     if (!response.ok) {
       console.warn('Failed to fetch Amazon page:', response.status, response.statusText);
       return '';

--- a/source/edge/background.js
+++ b/source/edge/background.js
@@ -10,12 +10,19 @@ const colorMap = {
 
 async function fetchHighResCover(amazonLink) {
   try {
-    if (!amazonLink || !amazonLink.includes('amazon.com') || !amazonLink.includes('/dp/')) {
+    if (!amazonLink || !amazonLink.includes('amazon') || !amazonLink.includes('/dp/')) {
       console.warn('Invalid Amazon link:', amazonLink);
       return '';
     }
 
-    const response = await fetch(amazonLink, { method: 'GET', credentials: 'omit' });
+    // Normalize URL to use www subdomain to match host_permissions
+    let normalizedUrl = amazonLink;
+    if (amazonLink.includes('://amazon.')) {
+      normalizedUrl = amazonLink.replace('://amazon.', '://www.amazon.');
+    }
+    console.log('Fetching cover from:', normalizedUrl);
+
+    const response = await fetch(normalizedUrl, { method: 'GET', credentials: 'omit' });
     if (!response.ok) {
       console.warn('Failed to fetch Amazon page:', response.status, response.statusText);
       return '';

--- a/source/mozilla/background.js
+++ b/source/mozilla/background.js
@@ -10,12 +10,19 @@ const colorMap = {
 
 async function fetchHighResCover(amazonLink) {
   try {
-    if (!amazonLink || !amazonLink.includes('amazon.com') || !amazonLink.includes('/dp/')) {
+    if (!amazonLink || !amazonLink.includes('amazon') || !amazonLink.includes('/dp/')) {
       console.warn('Invalid Amazon link:', amazonLink);
       return '';
     }
 
-    const response = await fetch(amazonLink, { method: 'GET', credentials: 'omit' });
+    // Normalize URL to use www subdomain to match host_permissions
+    let normalizedUrl = amazonLink;
+    if (amazonLink.includes('://amazon.')) {
+      normalizedUrl = amazonLink.replace('://amazon.', '://www.amazon.');
+    }
+    console.log('Fetching cover from:', normalizedUrl);
+
+    const response = await fetch(normalizedUrl, { method: 'GET', credentials: 'omit' });
     if (!response.ok) {
       console.warn('Failed to fetch Amazon page:', response.status, response.statusText);
       return '';


### PR DESCRIPTION
The Amazon links from Kindle pages use 'amazon.com' without 'www', but host_permissions only include 'www.amazon.com/*'. This caused CORS errors when trying to fetch high-resolution book covers.

Fix: Normalize the Amazon URL to use 'www' subdomain before fetching, ensuring it matches the host_permissions pattern.

Example:
- Before: https://amazon.com/dp/B00A3DL9PE (CORS blocked)
- After: https://www.amazon.com/dp/B00A3DL9PE (allowed)

Also updated the validation check to support all Amazon regional domains.