### PR TITLE
Fix language-specific highlight count text

### DIFF
--- a/source/chrome/background.js
+++ b/source/chrome/background.js
@@ -280,12 +280,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return blocks;
         }).flat();
 
+        // Count block with language-neutral format
+        // If matching this block in the future, use regex: /\d+\s*(?:Highlight|Destaque|Subrayado|Surlignage|Evidenziazione|ハイライト)/i
         const countBlock = {
           type: 'paragraph',
           paragraph: {
             rich_text: [
               {
-                text: { content: `${highlightCount} Destaque(s) | ${noteCount} Nota(s)` },
+                text: { content: `${highlightCount} Highlight(s) | ${noteCount} Note(s)` },
                 annotations: { bold: true }
               }
             ]
@@ -356,7 +358,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
         console.log('All appends completed successfully');
-        sendResponse({ status: `Export successful! ${highlightCount} Destaque(s) | ${noteCount} Nota(s)` });
+        sendResponse({ status: `Export successful! ${highlightCount} Highlight(s) | ${noteCount} Note(s)` });
       } catch (error) {
         console.error('Overall error:', error);
         sendResponse({ status: 'Error: ' + error.message });

--- a/source/edge/background.js
+++ b/source/edge/background.js
@@ -280,12 +280,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return blocks;
         }).flat();
 
+        // Count block with language-neutral format
+        // If matching this block in the future, use regex: /\d+\s*(?:Highlight|Destaque|Subrayado|Surlignage|Evidenziazione|ハイライト)/i
         const countBlock = {
           type: 'paragraph',
           paragraph: {
             rich_text: [
               {
-                text: { content: `${highlightCount} Destaque(s) | ${noteCount} Nota(s)` },
+                text: { content: `${highlightCount} Highlight(s) | ${noteCount} Note(s)` },
                 annotations: { bold: true }
               }
             ]
@@ -356,7 +358,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
         console.log('All appends completed successfully');
-        sendResponse({ status: `Export successful! ${highlightCount} Destaque(s) | ${noteCount} Nota(s)` });
+        sendResponse({ status: `Export successful! ${highlightCount} Highlight(s) | ${noteCount} Note(s)` });
       } catch (error) {
         console.error('Overall error:', error);
         sendResponse({ status: 'Error: ' + error.message });

--- a/source/mozilla/background.js
+++ b/source/mozilla/background.js
@@ -280,12 +280,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return blocks;
         }).flat();
 
+        // Count block with language-neutral format
+        // If matching this block in the future, use regex: /\d+\s*(?:Highlight|Destaque|Subrayado|Surlignage|Evidenziazione|ハイライト)/i
         const countBlock = {
           type: 'paragraph',
           paragraph: {
             rich_text: [
               {
-                text: { content: `${highlightCount} Destaque(s) | ${noteCount} Nota(s)` },
+                text: { content: `${highlightCount} Highlight(s) | ${noteCount} Note(s)` },
                 annotations: { bold: true }
               }
             ]
@@ -356,7 +358,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
         console.log('All appends completed successfully');
-        sendResponse({ status: `Export successful! ${highlightCount} Destaque(s) | ${noteCount} Nota(s)` });
+        sendResponse({ status: `Export successful! ${highlightCount} Highlight(s) | ${noteCount} Note(s)` });
       } catch (error) {
         console.error('Overall error:', error);
         sendResponse({ status: 'Error: ' + error.message });


### PR DESCRIPTION
Replace hardcoded Portuguese "Destaque(s)" and "Nota(s)" with English "Highlight(s)" and "Note(s)" to support all Kindle language settings.

Changes:
- Updated count block text to use language-neutral English format
- Updated success message to use English instead of Portuguese
- Added comment with multi-language regex pattern for future count block matching
- Applied fix across all three browser versions (chrome, edge, mozilla)

The regex pattern /\d+\s*(?:Highlight|Destaque|Subrayado|Surlignage|Evidenziazione|ハイライト)/i can be used if future code needs to match count blocks created in different languages.